### PR TITLE
Allow defining server URL via enviroment var in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ TS := $(shell find src -type f \( -name '*.ts' -or -name '*.tsx' \) )
 LUA := $(shell find src -type f -name '*.lua')
 BUILD_TS := $(TS:src/%=build/%)
 
+defaultServerURL="://cloud-catcher.squiddev.cc"
+
 .PHONEY: lint serve all clean
 
 all: public/assets/main.js build
@@ -38,7 +40,6 @@ public/assets/main.js: build
 
 public/cloud.lua: $(LUA)
 	cd src/host; \
-	defaultServerURL="://cloud-catcher.squiddev.cc"; \
 	lua _make.lua ../../public/cloud.lua "${cloudCatcherServerURL:-$defaultServerURL}"
 
 serve: build

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ public/assets/main.js: build
 public/cloud.lua: $(LUA)
 	cd src/host; \
 	if [ -z "$(cloudCatcherServerURL+x)" ]; then cloudCatcherServerURL="://cloud-catcher.squiddev.cc"; fi # see https://stackoverflow.com/a/13864829
-	lua _make.lua ../../public/cloud.lua $(cloudCatcherServerURL)
+	lua _make.lua ../../public/cloud.lua "$(cloudCatcherServerURL)"
 
 serve: build
 	tsc --project tsconfig.json --watch & \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ public/assets/main.js: build
 
 public/cloud.lua: $(LUA)
 	cd src/host; \
-	if [ -z "$(cloudCatcherServerURL+x)" ]; then cloudCatcherServerURL="://cloud-catcher.squiddev.cc"; fi # see https://stackoverflow.com/a/13864829
+	if [ -z "${cloudCatcherServerURL+x}" ]; then cloudCatcherServerURL="://cloud-catcher.squiddev.cc"; fi # see https://stackoverflow.com/a/13864829
 	lua _make.lua ../../public/cloud.lua "$(cloudCatcherServerURL)"
 
 serve: build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: public/assets/main.js build
 clean:
 	rm -rf build dist
 
-dist: package.json package-lock.json build public/index.html public/404.html public/assets/main.css public/assets/main.js public/assets/monaco-worker.js public/assets/termFont.png public/cloud.lua
+dist: package.json package-lock.json build public/index.html public/assets/main.css public/assets/main.js public/assets/termFont.png public/cloud.lua
 	rm -rf dist
 	mkdir dist
 	cp package.json package-lock.json dist
@@ -19,16 +19,12 @@ dist: package.json package-lock.json build public/index.html public/404.html pub
 	mkdir dist/build
 	cp -r build/*.js build/server dist/build
 
-	mkdir -p dist/public
-	cp public/index.html dist/public
-	cp public/404.html dist/public
-	cp public/cloud.lua dist/public
-
 	mkdir -p dist/public/assets
+	cp public/index.html dist/public
+	cp public/cloud.lua dist/public
 	cp public/assets/termFont.png dist/public/assets
 	uglifycss public/assets/main.css > dist/public/assets/main.css
 	uglifyjs public/assets/main.js > dist/public/assets/main.js
-	uglifyjs public/assets/monaco-worker.js > dist/public/assets/monaco-worker.js
 
 lint: $(TS) tsconfig.json tslint.json
 	tslint --project tsconfig.json
@@ -42,9 +38,10 @@ public/assets/main.js: build
 
 public/cloud.lua: $(LUA)
 	cd src/host; \
-	lua _make.lua ../../public/cloud.lua
+	if [ -z "$(cloudCatcherServerURL+x)" ]; then cloudCatcherServerURL="://cloud-catcher.squiddev.cc"; fi # see https://stackoverflow.com/a/13864829
+	lua _make.lua ../../public/cloud.lua $(cloudCatcherServerURL)
 
-serve: build public/cloud.lua
+serve: build
 	tsc --project tsconfig.json --watch & \
 	rollup -c --watch & \
 	node -r esm build/server & \

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ public/assets/main.js: build
 
 public/cloud.lua: $(LUA)
 	cd src/host; \
-	if [ -z "${cloudCatcherServerURL+x}" ]; then cloudCatcherServerURL="://cloud-catcher.squiddev.cc"; fi # see https://stackoverflow.com/a/13864829
-	lua _make.lua ../../public/cloud.lua "$(cloudCatcherServerURL)"
+	defaultServerURL="://cloud-catcher.squiddev.cc"; \
+	lua _make.lua ../../public/cloud.lua "${cloudCatcherServerURL:-$defaultServerURL}"
 
 serve: build
 	tsc --project tsconfig.json --watch & \

--- a/README.md
+++ b/README.md
@@ -20,3 +20,14 @@ to the computer.
 ![Sharing a session across multiple browsers](img/03-share.png "Sharing a session across multiple browsers")
 
 Share your session with other people, allowing for a true multiplayer-notepad.
+
+## Contributing
+Contributions are more than welcome to Cloud Catcher, though I warn you the code does get rather messy at times. I
+should warn you that building CC does get a little messy: it requires `make`, `lua` and Node.
+
+ - Clone the repository and `cd` into it as normal.
+ - Run `npm install` to get all node dependencies.
+ - Run `make serve` in order to run a development server (on port `:8080`) or `make dist` to generate a distribution.
+
+You can also run `make SERVER=cc.fancy.com dist` (or similar) to generate a build using an alternative server name. You
+may need to run `make clean` before changing this, to ensure files are regenerated.

--- a/src/host/_make.lua
+++ b/src/host/_make.lua
@@ -1,7 +1,6 @@
 #!/usr/bin/env lua
-local pack = pack or (table and table.pack)
-local args = pack(...)
-local out, err = io.open(args[1], "w")
+local file, serverURL = ...
+local out, err = io.open(file, "w")
 if not out then error(err, 0) end
 
 local function has_content(line)
@@ -22,11 +21,9 @@ for _, dep in pairs { "argparse", "framebuffer", "encode", "json" } do
     out:write("end\n")
 end
 
-local cloudCatcherServerURL = args[2] or "://localhost:8080" -- If this variable is not set by the arg then we assume that there is some local testing
-
 for line in io.lines("init.lua") do
   if has_content(line) then
-    out:write(line:gsub("://localhost:8080", cloudCatcherServerURL) .. "\n")
+    out:write(line:gsub("://localhost:8080", serverURL) .. "\n")
   end
 end
 

--- a/src/host/_make.lua
+++ b/src/host/_make.lua
@@ -20,10 +20,15 @@ for _, dep in pairs { "argparse", "framebuffer", "encode", "json" } do
     out:write("end\n")
 end
 
+local cloudCatcherServerURL = "://cloud-catcher.squiddev.cc"
+if type(os) == "table" and type(os.getenv) == "function" then
+  local envURL = os.getenv("cloudCatcherServerURL")
+  cloudCatcherServerURL = envURL or cloudCatcherServerURL
+end
 
 for line in io.lines("init.lua") do
   if has_content(line) then
-    out:write(line:gsub("://localhost:8080", "://cloud-catcher.squiddev.cc") .. "\n")
+    out:write(line:gsub("://localhost:8080", cloudCatcherServerURL) .. "\n")
   end
 end
 

--- a/src/host/_make.lua
+++ b/src/host/_make.lua
@@ -1,5 +1,5 @@
 #!/usr/bin/env lua
-local file, serverURL = ...
+local file, server = ...
 local out, err = io.open(file, "w")
 if not out then error(err, 0) end
 
@@ -23,7 +23,7 @@ end
 
 for line in io.lines("init.lua") do
   if has_content(line) then
-    out:write(line:gsub("://localhost:8080", serverURL) .. "\n")
+    out:write(line:gsub("localhost:8080", server) .. "\n")
   end
 end
 

--- a/src/host/_make.lua
+++ b/src/host/_make.lua
@@ -1,5 +1,7 @@
 #!/usr/bin/env lua
-local out, err = io.open(..., "w")
+local pack = pack or (table and table.pack)
+local args = pack(...)
+local out, err = io.open(args[1], "w")
 if not out then error(err, 0) end
 
 local function has_content(line)
@@ -20,11 +22,7 @@ for _, dep in pairs { "argparse", "framebuffer", "encode", "json" } do
     out:write("end\n")
 end
 
-local cloudCatcherServerURL = "://cloud-catcher.squiddev.cc"
-if type(os) == "table" and type(os.getenv) == "function" then
-  local envURL = os.getenv("cloudCatcherServerURL")
-  cloudCatcherServerURL = envURL or cloudCatcherServerURL
-end
+local cloudCatcherServerURL = args[2] or "://localhost:8080" -- If this variable is not set by the arg then we assume that there is some local testing
 
 for line in io.lines("init.lua") do
   if has_content(line) then


### PR DESCRIPTION
The value subbed for `://localhost:8080` is now able to be defined by the environment variable `cloudCatcherServerURL`. If this value is null then `://cloud-catcher.squiddev.cc` is used as a default.

This allows users to easily build and deploy their own servers without having to find and edit this file.