### PR TITLE
Fix error output when given incorrect subcommand

### DIFF
--- a/src/host/init.lua
+++ b/src/host/init.lua
@@ -62,7 +62,7 @@ if _G.cloud_catcher then
     error()
 
   else
-    error(("%q is not a cloud catcher subcommand, run with --h for more info"):format(subcommand), 0)
+    error(("%q is not a cloud catcher subcommand, run with --help for more info"):format(subcommand), 0)
   end
 
   return


### PR DESCRIPTION
This pull request fixes the following output:
```
> cloud --h
"--h" is not a cloud catcher subcommand, run with --h for more info
```
![image](https://user-images.githubusercontent.com/39929480/146702196-6cf70fa0-8c59-4df8-85b6-5d446345b11b.png)
